### PR TITLE
TAUR-4226 | invalid apiVersion "client.authentication.k8s.io/v1alpha1"

### DIFF
--- a/run_pre_deploy.sh
+++ b/run_pre_deploy.sh
@@ -11,7 +11,7 @@ if ! [ -x "$(command -v kubectl)" ]; then
   wget --no-check-certificate -qO - https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
   echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list
   apt-get update
-  apt-get install -y kubectl
+  apt-get install -y kubectl=1.22.5-00
 fi;
 
 # Install AWS CLI


### PR DESCRIPTION
On branch TAUR-4226

modified:   run_pre_deploy.sh

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->